### PR TITLE
BugFix - App crashes after exiting Saved Report

### DIFF
--- a/open311-android/src/gov/in/bloomington/georeporter/fragments/SavedReportViewFragment.java
+++ b/open311-android/src/gov/in/bloomington/georeporter/fragments/SavedReportViewFragment.java
@@ -214,6 +214,8 @@ public class SavedReportViewFragment extends SherlockFragment {
                 } catch (JSONException e) {
                     // TODO Auto-generated catch block
                     e.printStackTrace();
+                } catch (NullPointerException e) {
+                    e.printStackTrace();
                 }
             }
         }


### PR DESCRIPTION
I've found out that problem lies in RefreshFromServerTask. As you open Saved Report, new RefreshFromServerTask launches in background (as AsyncTask) and tries to get data from server. But if you have slow connection this process may take a long time. And if you exit Saved Report before RefreshFromServerTask  finishes, application crashes with NullPointerException. This happens because RefreshFromServerTask   (in onPostExecute) calls refreshViewData(). It is okay if user is still in Saved Report, but if not, refreshViewData() tries to refresh View which now doesn't exist.
The best way to handle this error is to catch NullPointerException in onPostExecute.
