### PR TITLE
Service request data must be UTF-8 encoded

### DIFF
--- a/open311-android/src/gov/in/bloomington/georeporter/models/Open311.java
+++ b/open311-android/src/gov/in/bloomington/georeporter/models/Open311.java
@@ -18,6 +18,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -117,6 +118,8 @@ public class Open311 {
 	// Key names for formats
 	public 	static final String JSON = "json";
 	public  static final String XML  = "xml";
+	// Key name for encoding
+	public 	static final String UTF_8 = "UTF-8";
 
 	
 	
@@ -426,7 +429,7 @@ public class Open311 {
                 e.printStackTrace();
             }
         }
-        return new UrlEncodedFormEntity(pairs);
+        return new UrlEncodedFormEntity(pairs,UTF_8);
 	}
 	
 	/**
@@ -490,7 +493,8 @@ public class Open311 {
                     if (o instanceof Double) {
                         o = Double.toString((Double)o);
                     }
-                    post.addPart(key, new StringBody((String) o));
+                    Charset charset = Charset.forName(UTF_8);
+                    post.addPart(key, new StringBody((String) o, charset));
                 }
             } catch (JSONException e) {
                 // TODO Auto-generated catch block


### PR DESCRIPTION
As the Open311 spec describes, content of service requests needs to be UTF-8 encoded. This also corrects that chars like äöå are sent correctly.

This solves issue https://github.com/City-of-Bloomington/open311-android/issues/70 
