### PR TITLE
Async refactoring

### DIFF
--- a/open311-android/src/gov/in/bloomington/georeporter/adapters/SavedReportsAdapter.java
+++ b/open311-android/src/gov/in/bloomington/georeporter/adapters/SavedReportsAdapter.java
@@ -19,6 +19,8 @@ import gov.in.bloomington.georeporter.util.json.JSONObject;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.graphics.Bitmap;
+import android.os.AsyncTask;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -64,7 +66,7 @@ public class SavedReportsAdapter extends BaseAdapter {
 
 	@Override
 	public View getView(int position, View convertView, ViewGroup parent) {
-		ViewHolder holder;
+		final ViewHolder holder;
 		if (convertView == null) {
 			convertView = mInflater.inflate(R.layout.list_item_saved_reports, null);
 			holder = new ViewHolder();
@@ -80,14 +82,24 @@ public class SavedReportsAdapter extends BaseAdapter {
 			holder = (ViewHolder) convertView.getTag();
 		}
 		
-        ServiceRequest sr = getItem(position);
+        final ServiceRequest sr = getItem(position);
 		try {
 			holder.serviceName.setText(sr.service        .getString(Open311.SERVICE_NAME));
 			holder.endpoint   .setText(sr.endpoint       .getString(Open311.NAME));
 			holder.address    .setText(sr.post_data      .optString(Open311.ADDRESS_STRING));
 			holder.status     .setText(sr.service_request.optString(ServiceRequest.STATUS));
             holder.date       .setText(mDateFormat.format(mISODate.parse(sr.post_data.optString(ServiceRequest.REQUESTED_DATETIME))));
-            holder.media.setImageBitmap(sr.getMediaBitmap(80, 80, mInflater.getContext()));
+            new AsyncTask<Void, Void, Bitmap>() {
+                @Override
+                protected Bitmap doInBackground(Void... params) {
+                    return sr.getMediaBitmap(80, 80, mInflater.getContext());
+                }
+
+                @Override
+                protected void onPostExecute(Bitmap bitmap) {
+                    holder.media.setImageBitmap(bitmap);
+                }
+            }.execute();
 		} catch (JSONException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();

--- a/open311-android/src/gov/in/bloomington/georeporter/adapters/ServiceRequestAdapter.java
+++ b/open311-android/src/gov/in/bloomington/georeporter/adapters/ServiceRequestAdapter.java
@@ -23,6 +23,7 @@ import gov.in.bloomington.georeporter.util.json.JSONObject;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.os.AsyncTask;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -207,10 +208,19 @@ public class ServiceRequestAdapter extends BaseAdapter {
                     media = (MediaViewHolder)convertView.getTag();
                 }
 
-                Bitmap bmp = mServiceRequest.getMediaBitmap(80, 80, mLayoutInflater.getContext());
-                if (bmp != null) {
-                    media.image.setImageBitmap(bmp);
-                }
+                new AsyncTask<Void, Void, Bitmap>() {
+                    @Override
+                    protected Bitmap doInBackground(Void... params) {
+                        return mServiceRequest.getMediaBitmap(80, 80, mLayoutInflater.getContext());
+                    }
+
+                    @Override
+                    protected void onPostExecute(Bitmap bmp) {
+                        if (bmp != null) {
+                            media.image.setImageBitmap(bmp);
+                        }
+                    }
+                }.execute();
 
                 break;
 

--- a/open311-android/src/gov/in/bloomington/georeporter/fragments/SavedReportViewFragment.java
+++ b/open311-android/src/gov/in/bloomington/georeporter/fragments/SavedReportViewFragment.java
@@ -20,6 +20,7 @@ import gov.in.bloomington.georeporter.util.json.JSONArray;
 import gov.in.bloomington.georeporter.util.json.JSONException;
 import gov.in.bloomington.georeporter.util.json.JSONObject;
 import android.app.Fragment;
+import android.graphics.Bitmap;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -76,8 +77,18 @@ public class SavedReportViewFragment extends Fragment {
         textView = (TextView) v.findViewById(R.id.service_name);
         textView.setText(mServiceRequest.service.optString(Open311.SERVICE_NAME));
         
-        ImageView media = (ImageView) v.findViewById(R.id.media);
-        media.setImageBitmap(mServiceRequest.getMediaBitmap(100, 100, getActivity()));
+        final ImageView media = (ImageView) v.findViewById(R.id.media);
+        new AsyncTask<Void, Void, Bitmap>() {
+            @Override
+            protected Bitmap doInBackground(Void... params) {
+                return mServiceRequest.getMediaBitmap(100, 100, getActivity());
+            }
+
+            @Override
+            protected void onPostExecute(Bitmap bmp) {
+                media.setImageBitmap(bmp);
+            }
+        }.execute();
         
         textView = (TextView) v.findViewById(R.id.address);
         if (mServiceRequest.service_request.has(Open311.ADDRESS)) {

--- a/open311-android/src/gov/in/bloomington/georeporter/fragments/SavedReportViewFragment.java
+++ b/open311-android/src/gov/in/bloomington/georeporter/fragments/SavedReportViewFragment.java
@@ -208,8 +208,18 @@ public class SavedReportViewFragment extends Fragment {
             if (dataUpdated) {
                 try {
                     mServiceRequests.put(mPosition, new JSONObject(mServiceRequest.toString()));
-                    Open311.saveServiceRequests(getActivity(), mServiceRequests);
-                    refreshViewData();
+                    new AsyncTask<Void, Void, Void>() {
+                        @Override
+                        protected Void doInBackground(Void... params) {
+                            Open311.saveServiceRequests(getActivity(), mServiceRequests);
+                            return null;
+                        }
+                        
+                        @Override
+                        protected void onPostExecute(Void result) {
+                            refreshViewData();
+                        }
+                    }.execute();
                 } catch (JSONException e) {
                     // TODO Auto-generated catch block
                     e.printStackTrace();

--- a/open311-android/src/gov/in/bloomington/georeporter/fragments/SavedReportsListFragment.java
+++ b/open311-android/src/gov/in/bloomington/georeporter/fragments/SavedReportsListFragment.java
@@ -63,7 +63,12 @@ public class SavedReportsListFragment extends ListFragment {
 	@Override
 	public void onPause() {
 	    if (mDataChanged) {
-	        Open311.saveServiceRequests(getActivity(), mServiceRequests);
+	        new Thread() {
+	            @Override
+	            public void run() {
+	    	        Open311.saveServiceRequests(getActivity(), mServiceRequests);
+	            }
+	        }.start();
 	    }
 	    super.onPause();
 	}


### PR DESCRIPTION
Hi, I'm doing research on performance for Android apps. I found some event handlers access disk or decoding bitmap from UI thread, but Android docs suggest us to avoid such blocking calls in UI thread. Do they lead to any responsiveness issues?

I tried to refactoring by putting them into background tasks. Looking forward to see your comments.